### PR TITLE
add conditionals to work with doc-view-mode

### DIFF
--- a/saveplace-pdf-view.el
+++ b/saveplace-pdf-view.el
@@ -1,12 +1,12 @@
 ;;; saveplace-pdf-view.el --- Save place in pdf-view buffers -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2020 Nicolai Singh
+;; Copyright (C) 2020-2021 Nicolai Singh
 
 ;; Author: Nicolai Singh <nicolaisingh at pm.me>
 ;; URL: https://github.com/nicolaisingh/saveplace-pdf-view
-;; Version: 1.0.3
+;; Version: 1.0.4
 ;; Keywords: files, convenience
-;; Package-Requires: ((emacs "24.1") (pdf-tools "1.0"))
+;; Package-Requires: ((emacs "24.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -23,14 +23,21 @@
 
 ;;; Commentary:
 
-;; Adds support for pdf-view (from `pdf-tools') buffers in
+;; Adds support for pdf-view (from `pdf-tools') and DocView buffers in
 ;; `save-place-mode'.
-;;
-;; If using pdf-view-mode, this package will automatically persist
-;; between Emacs sessions the current PDF page, size and other
-;; information returned by `pdf-view-bookmark-make-record' using
-;; `save-place-mode'.  Visiting the same PDF file will restore the
-;; previously displayed page and size.
+
+;; If using pdf-view-mode or doc-view-mode, this package will
+;; automatically persist between Emacs sessions the current PDF page,
+;; size and other information from `pdf-view-bookmark-make-record' or
+;; `doc-view-bookmark-make-record', depending on the mode used.  These
+;; information are persisted using `save-place-mode'.  Visiting the
+;; same PDF file will restore the previously displayed page and scale
+;; amount (if available).
+
+;;; Acknowledgements:
+
+;; - João Pedro <jpedrodeamorim@gmail.com>, for making the package
+;;   work with doc-view-mode
 
 ;;; Code:
 


### PR DESCRIPTION
this simply adds a bunch of `cond`'s to work with `doc-view-mode` and ` doc-view-bookmark-make-record` for buffers that are currently using `doc-view-mode`. it checks for `pdf-view-mode` first since it is derived from `doc-view-mode`, so checking if the current major mode `pdf-view-mode` is derived from `doc-view-mode`. this change was proposd on #5.