### PR TITLE
Demote errors when creating bookmark record

### DIFF
--- a/saveplace-pdf-view.el
+++ b/saveplace-pdf-view.el
@@ -78,12 +78,12 @@ doc-view bookmark will replace the file's pdf-view bookmark."
                (or (not save-place-ignore-files-regexp)
                    (not (string-match save-place-ignore-files-regexp
                                       item))))
-      (let* ((cell (assoc item save-place-alist))
-             (bookmark (funcall make-record-function))
-             (page (assoc 'page bookmark))
-             (origin (assoc 'origin bookmark)))
-        (with-demoted-errors
-            "Error saving place: %S"
+      (with-demoted-errors
+          "Error saving place: %S"
+        (let* ((cell (assoc item save-place-alist))
+               (bookmark (funcall make-record-function))
+               (page (assoc 'page bookmark))
+               (origin (assoc 'origin bookmark)))
           (when cell
             (setq save-place-alist (delq cell save-place-alist)))
           (when (and save-place-mode


### PR DESCRIPTION
This PR updates `saveplace-pdf-view-to-alist` to demote errors earlier, so that errors raised when creating the bookmark record are demoted and don't keep buffers from being killed.

This fixes the issue in #8. I've seen this occur when for example `pdf-tools` is not yet properly installed, and a buffer is opened in `pdf-view-mode`, but is not actually displaying pdf pages. This leads to the error reported, and keeps the broken pdf-view-mode buffer from being killed. Demoting errors when calling the `make-record-function` should address this.